### PR TITLE
Add APB as dependency

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -7,7 +7,7 @@ package:
 
 dependencies:
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.13.1 }
-  apb: { git: "https://github.com/pulp-platform/apb.git", version:  0.1.0 }
+  apb: { git: "https://github.com/pulp-platform/apb.git", version: 0.2.0 }
 
 sources:
   - apb_interrupt_cntrl.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -7,6 +7,7 @@ package:
 
 dependencies:
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.13.1 }
+  apb: { git: "https://github.com/pulp-platform/apb.git", version:  0.1.0 }
 
 sources:
   - apb_interrupt_cntrl.sv

--- a/apb_interrupt_cntrl.sv
+++ b/apb_interrupt_cntrl.sv
@@ -49,7 +49,7 @@ module apb_interrupt_cntrl
   output logic           fetch_en_o,
 
   // bus slave connections - periph bus and eu_direct_link
-  APB_BUS.Slave          apb_slave
+  APB.Slave              apb_slave
  );
 
   logic             [31:0] s_events;

--- a/apb_interrupt_cntrl.sv
+++ b/apb_interrupt_cntrl.sv
@@ -127,7 +127,7 @@ module apb_interrupt_cntrl
     .valid_o ( s_event_fifo_valid ),
     .grant_i ( s_event_fifo_ready ),
 
-    .test_mode_i()
+    .test_mode_i
   );
 
   always_comb begin : proc_mask


### PR DESCRIPTION
The apb interrupt controller uses the APB_BUS SystemVerilog interface. The corresponding IP should thus be part of the Bender dependency list. This PR changes the APB version to 0.2.0 which introduced a breaking change (renaming the interface from APB_BUS to APB). 